### PR TITLE
Prepare for release

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This plugin offer several configurations depending on your project type.
 
 ```shell
 yarn add -D @fewlines/eslint-config eslint \
-eslint-config-prettier eslint-plugin-prettier prettier \
+eslint-config-prettier eslint-plugin-prettier prettier
 ```
 
 Then add these lines to your package.json:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# eslint-config-fewlines
+# eslint-config
 
 Disclaimer: this package is made for our internal usage and is only open source for convenience so we might not consider Pull Requests or Issues.
 Feel free to fork though.
@@ -9,6 +9,8 @@ This package includes the different styles we apply to our JavaScript and TypeSc
 The goal is to not have the editor run prettier directly as it would conflict with ESLint.
 
 See here for VSCode: https://github.com/prettier/prettier-vscode#vs-code-eslint-and-tslint-integration
+
+Vim users could use [ALE](https://github.com/dense-analysis/ale) and use `let g:ale_fix_on_save = 1` and `eslint` as the linter for JavaScript and TypeScript.
 
 ## Usage
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "name": "@fewlines/eslint-config",
   "repository": "git@github.com:fewlinesco/eslint-config.git",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "eslintConfig": {
     "extends": "./node"
   },


### PR DESCRIPTION
## Detailed Description

This PR changes the name of the project in the README as we changed the repo name but forgot the README and corrects a typo in the yarn command, adds a little mention about vim users because why not and set the version to 1.0.0 for the first release.

The README was tested on several of our projects to see if it worked with `fewlinesco/eslint-config#master` version and it went well 3 times :)

## Related Story

[ch995]