### PR TITLE
Add es6 env to node [CU-6cux8z]

### DIFF
--- a/node.js
+++ b/node.js
@@ -1,6 +1,7 @@
 module.exports = {
   env: {
     node: true,
+    es6: true,
   },
   parserOptions: {
     ecmaVersion: 2020,


### PR DESCRIPTION
This PR adds `es6:true` to the `env` object because this is a different parameter than `ecmaVersion`.

From what I understood, `es6` will allow using things like `Promise` and `ecmaVersion` things like `string.padLeft`. ¯\_(ツ)_/¯