### PR TITLE
Add export rules + bump + improve doc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## 3.1.0 - 2021-01-22
+## 3.1.0 - 2021-01-29
 
 - Added rules for export. See documentation.
 - Added import path group rule. `@src/**` is now considered an internal import.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # CHANGELOG
 
+## 3.1.0 - 2021-01-22
+
+- Added rules for export. See documentation.
+- Added import path group rule. `@src/**` is now considered an internal import.
+
+### Bump of dependencies
+
+```ts
+  @typescript-eslint/eslint-plugin  dev    ~1mo  4.11.0  →  4.14.0   ~4d
+  @typescript-eslint/parser         dev    ~1mo  4.11.0  →  4.14.0   ~4d
+  eslint                            dev    ~1mo  7.16.0  →  7.18.0   ~6d
+  eslint-config-prettier            dev    ~1mo   7.1.0  →   7.2.0   ~4d
+  eslint-plugin-prettier            dev    ~1mo   3.3.0  →   3.3.1  ~18d
+
+  4 minor, 1 patch updates
+```
+
 ## 3.0.0 - 2020-07-16
 
 - Made `typescript.ts` extend `node.ts` configuration.

--- a/README.adoc
+++ b/README.adoc
@@ -1,4 +1,5 @@
-# eslint-config
+= eslint-config
+:toc: preamble
 
 Disclaimer: this package is made for our internal usage and is only open source for convenience so we might not consider Pull Requests or Issues.
 Feel free to fork though.
@@ -7,133 +8,19 @@ This package includes the different styles we apply to our JavaScript and TypeSc
 
 ⚠️ As this plugin wants to use a minimalist configuration, it relies on using prettier via ESLint which means you could have to configure your editor. The goal is to not have the editor run prettier directly as it would conflict with ESLint.
 
-Jump [here](#vs-code) for VSCode integration.
+== Text Editor
 
-Vim users could use [ALE](https://github.com/dense-analysis/ale) and use `let g:ale_fix_on_save = 1` and `eslint` as the linter for JavaScript and TypeScript.
-
-## Usage
-
-This plugin offer several configurations depending on your project type.
-
-### Node project
-
-```shell
-yarn add -D @fewlines/eslint-config eslint \
-eslint-config-prettier eslint-plugin-prettier prettier \
-eslint-plugin-import
-```
-
-Then add these lines to your package.json:
-
-```json
-"eslintConfig": {
-  "extends": "@fewlines/eslint-config/node"
-}
-```
-
----
-
-### TypeScript project
-
-```shell
-yarn add -D @fewlines/eslint-config eslint \
-eslint-config-prettier eslint-plugin-prettier prettier \
-@typescript-eslint/eslint-plugin @typescript-eslint/parser \
-eslint-plugin-import
-```
-
-Then add these lines to your package.json:
-
-```json
-"eslintConfig": {
-  "extends": "@fewlines/eslint-config/typescript"
-}
-```
-
-The TypeScript plugin extends the previous Node plugin so it is not needed.
-
----
-
-### React project
-
-```shell
-yarn add -D @fewlines/eslint-config eslint \
-eslint-config-prettier eslint-plugin-prettier prettier \
-eslint-plugin-react \
-eslint-plugin-import
-```
-
-Then add these lines to your package.json:
-
-```json
-"eslintConfig": {
-  "extends": "@fewlines/eslint-config/react"
-}
-```
-
-The React plugin extends the previous Node plugin so it is not needed.
-
----
-
-### React + TypeScript project
-
-⚠️ This preset only aim to remove the `prop-types` checks. You should use it along the `react` and `typescript` presets.
-
-```shell
-yarn add -D @fewlines/eslint-config eslint \
-eslint-config-prettier eslint-plugin-prettier prettier \
-@typescript-eslint/eslint-plugin @typescript-eslint/parser \
-eslint-plugin-react \
-eslint-plugin-import
-```
-
-Then add these lines to your `package.json`:
-
-```json
-"eslintConfig": {
-  "extends": [
-    "@fewlines/eslint-config/typescript",
-    "@fewlines/eslint-config/react",
-    "@fewlines/eslint-config/react-typescript"
-  ]
-}
-```
-
-The React + Typescript plugin extends the previous Node plugin so it is not needed.
-
----
-
-### Preact + TypeScript project
-
-```shell
-yarn add -D @fewlines/eslint-config eslint \
-eslint-config-prettier eslint-plugin-prettier prettier \
-@typescript-eslint/eslint-plugin @typescript-eslint/parser \
-eslint-plugin-import
-```
-
-Then add these lines to your `package.json`:
-
-```json
-"eslintConfig": {
-  "extends": "@fewlines/eslint-config/preact-typescript"
-}
-```
-
-The Preact + Typescript plugin extends the previous Node plugin so it is not needed.
-
----
-
-### <a id="vs-code"></a>VS Code integration
+=== VSCode
 
 In order to integrate `ESLint` into `VS Code`, install these two extensions:
 
-- [ESLint](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint)
-- [Prettier](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode)
+- https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint[ESLint]
+- https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode[Prettier]
 
-Then add these settings to your vscode's `settings.json`:
+Then add these settings to your VSCode's `settings.json`:
 
-```json
+[source, json]
+----
 "eslint.format.enable": true,
 "editor.defaultFormatter": "dbaeumer.vscode-eslint",
 "[javascript]": {
@@ -154,14 +41,137 @@ Then add these settings to your vscode's `settings.json`:
 "[json]": {
   "editor.defaultFormatter": "dbaeumer.vscode-eslint"
 }
-```
+----
 
 If the linter does not work right away, you can pop the `VS Code` command palette with `⌘ Cmd + ↑ Shift + P` on mac, or `Ctrl + ↑ Shift + P` on windows/linux, and set the default formatter:
 
-![VS Code default linter gif](https://user-images.githubusercontent.com/31956107/75045130-06f07800-54c3-11ea-8881-f9c9a50efea9.gif)
+image::https://user-images.githubusercontent.com/31956107/75045130-06f07800-54c3-11ea-8881-f9c9a50efea9.gif[VS Code default linter gif]
 
-For more information, check [this](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint) part of the documentation.
+For more information, https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint[check this part of the ESLint documentation].
 
-## Contributing
+=== Vim
 
-See [CONTRIBUTING.md](CONTRIBUTING.md).
+Vim users could use https://github.com/dense-analysis/ale[ALE] and use `let g:ale_fix_on_save = 1` and `eslint` as the linter for JavaScript and TypeScript.
+
+== General rules
+
+=== Import
+
+=== Export
+
+== Usage
+
+This plugin offer several configurations depending on your project type.
+
+=== Node project
+
+[source, shell]
+----
+yarn add -D @fewlines/eslint-config eslint \
+eslint-config-prettier eslint-plugin-prettier prettier \
+eslint-plugin-import
+----
+
+Then add these lines to your package.json:
+
+[source, json]
+----
+"eslintConfig": {
+  "extends": "@fewlines/eslint-config/node"
+}
+----
+
+=== TypeScript project
+
+[source, shell]
+----
+yarn add -D @fewlines/eslint-config eslint \
+eslint-config-prettier eslint-plugin-prettier prettier \
+@typescript-eslint/eslint-plugin @typescript-eslint/parser \
+eslint-plugin-import
+----
+
+Then add these lines to your package.json:
+
+[source, json]
+----
+"eslintConfig": {
+  "extends": "@fewlines/eslint-config/typescript"
+}
+----
+
+The TypeScript plugin extends the previous Node plugin so it is not needed.
+
+=== React project
+
+[source, shell]
+----
+yarn add -D @fewlines/eslint-config eslint \
+eslint-config-prettier eslint-plugin-prettier prettier \
+eslint-plugin-react \
+eslint-plugin-import
+----
+
+Then add these lines to your package.json:
+
+[source, json]
+----
+"eslintConfig": {
+  "extends": "@fewlines/eslint-config/react"
+}
+----
+
+The React plugin extends the previous Node plugin so it is not needed.
+
+=== React + TypeScript project
+
+⚠️ This preset only aim to remove the `prop-types` checks. You should use it along the `react` and `typescript` presets.
+
+[source, shell]
+----
+yarn add -D @fewlines/eslint-config eslint \
+eslint-config-prettier eslint-plugin-prettier prettier \
+@typescript-eslint/eslint-plugin @typescript-eslint/parser \
+eslint-plugin-react \
+eslint-plugin-import
+----
+
+Then add these lines to your `package.json`:
+
+[source, json]
+----
+"eslintConfig": {
+  "extends": [
+    "@fewlines/eslint-config/typescript",
+    "@fewlines/eslint-config/react",
+    "@fewlines/eslint-config/react-typescript"
+  ]
+}
+----
+
+The React + Typescript plugin extends the previous Node plugin so it is not needed.
+
+=== Preact + TypeScript project
+
+[source, shell]
+----
+yarn add -D @fewlines/eslint-config eslint \
+eslint-config-prettier eslint-plugin-prettier prettier \
+@typescript-eslint/eslint-plugin @typescript-eslint/parser \
+eslint-plugin-import
+----
+
+Then add these lines to your `package.json`:
+
+[source, json]
+----
+"eslintConfig": {
+  "extends": "@fewlines/eslint-config/preact-typescript"
+}
+----
+
+The Preact + Typescript plugin extends the previous Node plugin so it is not needed.
+
+== Contributing
+
+See xref:CONTRIBUTING.md[CONTRIBUTING.md].

--- a/README.adoc
+++ b/README.adoc
@@ -55,7 +55,7 @@ Vim users could use https://github.com/dense-analysis/ale[ALE] and use `let g:al
 
 == General rules
 
-To enforce consistency throughout our imports and export, we are using https://www.npmjs.com/package/eslint-plugin-import[eslint-plugin-export].
+To enforce consistency throughout our imports and exports, we are using https://www.npmjs.com/package/eslint-plugin-import[eslint-plugin-import].
 
 === Import
 

--- a/README.adoc
+++ b/README.adoc
@@ -75,7 +75,9 @@ import { Handler } from "./handler";
 
 === Export
 
-You can find all our rules on https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/group-exports.md[this document from eslint-plugin-import].
+For export rules, we are using:
+- https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/group-exports.md[group-exports].
+- https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/exports-last.md[exports-last].
 
 == Usage
 

--- a/README.adoc
+++ b/README.adoc
@@ -75,6 +75,8 @@ import { Handler } from "./handler";
 
 === Export
 
+You can find all our rules on https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/group-exports.md[this document from eslint-plugin-import].
+
 == Usage
 
 This plugin offer several configurations depending on your project type.

--- a/README.adoc
+++ b/README.adoc
@@ -55,7 +55,23 @@ Vim users could use https://github.com/dense-analysis/ale[ALE] and use `let g:al
 
 == General rules
 
+To enforce consistency throughout our imports and export, we are using https://www.npmjs.com/package/eslint-plugin-import[eslint-plugin-export].
+
 === Import
+
+The set of rules we chose to organize our imports are the following groups:
+
+- Built in and externals
+- Parents, siblings, indexes and path aliases
+
+[source, js]
+----
+import { IncomingMessage, ServerResponse } from "http";
+import React from "react"
+
+import { CustomError } from "@src/errors"
+import { Handler } from "./handler";
+----
 
 === Export
 

--- a/node.js
+++ b/node.js
@@ -21,6 +21,12 @@ module.exports = {
           ["builtin", "external"],
           ["parent", "sibling", "index"],
         ],
+        pathGroups: [
+          {
+            pattern: "@src/**",
+            group: "internal",
+          },
+        ],
       },
     ],
   },

--- a/node.js
+++ b/node.js
@@ -19,7 +19,7 @@ module.exports = {
         "newlines-between": "always",
         groups: [
           ["builtin", "external"],
-          ["parent", "sibling", "index"],
+          ["internal", "parent", "sibling", "index"],
         ],
         pathGroups: [
           {
@@ -29,5 +29,7 @@ module.exports = {
         ],
       },
     ],
+    "import/group-exports": "error",
+    "import/exports-last": "error",
   },
 };

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "name": "@fewlines/eslint-config",
   "repository": "git@github.com:fewlinesco/eslint-config.git",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "eslintConfig": {
     "extends": "./node",
     "env": {
@@ -12,12 +12,12 @@
     }
   },
   "devDependencies": {
-    "@typescript-eslint/eslint-plugin": "4.11.0",
-    "@typescript-eslint/parser": "4.11.0",
-    "eslint": "7.16.0",
-    "eslint-config-prettier": "7.1.0",
+    "@typescript-eslint/eslint-plugin": "4.14.0",
+    "@typescript-eslint/parser": "4.14.0",
+    "eslint": "7.18.0",
+    "eslint-config-prettier": "7.2.0",
     "eslint-plugin-import": "2.22.1",
-    "eslint-plugin-prettier": "3.3.0",
+    "eslint-plugin-prettier": "3.3.1",
     "jest": "26.6.3",
     "prettier": "2.2.1",
     "typescript": "4.1.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -328,10 +328,10 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@eslint/eslintrc@^0.2.2":
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-0.2.2.tgz#d01fc791e2fc33e88a29d6f3dc7e93d0cd784b76"
-  integrity sha512-EfB5OHNYp1F4px/LI/FEnGylop7nOqkQ1LRzCM0KccA2U8tvV8w01KBv37LbO7nW4H+YhKyo2LcJhRwjjV17QQ==
+"@eslint/eslintrc@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-0.3.0.tgz#d736d6963d7003b6514e6324bec9c602ac340318"
+  integrity sha512-1JTKgrOKAHVivSvOYw+sJOunkBjUOvjqWk1DPja7ZFhIS2mX/4EgTT8M7eTK9jrKhL/FvXXEbQwIs3pg1xp3dg==
   dependencies:
     ajv "^6.12.4"
     debug "^4.1.1"
@@ -340,7 +340,7 @@
     ignore "^4.0.6"
     import-fresh "^3.2.1"
     js-yaml "^3.13.1"
-    lodash "^4.17.19"
+    lodash "^4.17.20"
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
@@ -689,61 +689,62 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@typescript-eslint/eslint-plugin@4.11.0":
-  version "4.11.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.11.0.tgz#bc6c1e4175c0cf42083da4314f7931ad12f731cc"
-  integrity sha512-x4arJMXBxyD6aBXLm3W7mSDZRiABzy+2PCLJbL7OPqlp53VXhaA1HKK7R2rTee5OlRhnUgnp8lZyVIqjnyPT6g==
+"@typescript-eslint/eslint-plugin@4.14.0":
+  version "4.14.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.14.0.tgz#92db8e7c357ed7d69632d6843ca70b71be3a721d"
+  integrity sha512-IJ5e2W7uFNfg4qh9eHkHRUCbgZ8VKtGwD07kannJvM5t/GU8P8+24NX8gi3Hf5jST5oWPY8kyV1s/WtfiZ4+Ww==
   dependencies:
-    "@typescript-eslint/experimental-utils" "4.11.0"
-    "@typescript-eslint/scope-manager" "4.11.0"
+    "@typescript-eslint/experimental-utils" "4.14.0"
+    "@typescript-eslint/scope-manager" "4.14.0"
     debug "^4.1.1"
     functional-red-black-tree "^1.0.1"
+    lodash "^4.17.15"
     regexpp "^3.0.0"
     semver "^7.3.2"
     tsutils "^3.17.1"
 
-"@typescript-eslint/experimental-utils@4.11.0":
-  version "4.11.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-4.11.0.tgz#d1a47cc6cfe1c080ce4ead79267574b9881a1565"
-  integrity sha512-1VC6mSbYwl1FguKt8OgPs8xxaJgtqFpjY/UzUYDBKq4pfQ5lBvN2WVeqYkzf7evW42axUHYl2jm9tNyFsb8oLg==
+"@typescript-eslint/experimental-utils@4.14.0":
+  version "4.14.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-4.14.0.tgz#5aa7b006736634f588a69ee343ca959cd09988df"
+  integrity sha512-6i6eAoiPlXMKRbXzvoQD5Yn9L7k9ezzGRvzC/x1V3650rUk3c3AOjQyGYyF9BDxQQDK2ElmKOZRD0CbtdkMzQQ==
   dependencies:
     "@types/json-schema" "^7.0.3"
-    "@typescript-eslint/scope-manager" "4.11.0"
-    "@typescript-eslint/types" "4.11.0"
-    "@typescript-eslint/typescript-estree" "4.11.0"
+    "@typescript-eslint/scope-manager" "4.14.0"
+    "@typescript-eslint/types" "4.14.0"
+    "@typescript-eslint/typescript-estree" "4.14.0"
     eslint-scope "^5.0.0"
     eslint-utils "^2.0.0"
 
-"@typescript-eslint/parser@4.11.0":
-  version "4.11.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.11.0.tgz#1dd3d7e42708c10ce9f3aa64c63c0ab99868b4e2"
-  integrity sha512-NBTtKCC7ZtuxEV5CrHUO4Pg2s784pvavc3cnz6V+oJvVbK4tH9135f/RBP6eUA2KHiFKAollSrgSctQGmHbqJQ==
+"@typescript-eslint/parser@4.14.0":
+  version "4.14.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.14.0.tgz#62d4cd2079d5c06683e9bfb200c758f292c4dee7"
+  integrity sha512-sUDeuCjBU+ZF3Lzw0hphTyScmDDJ5QVkyE21pRoBo8iDl7WBtVFS+WDN3blY1CH3SBt7EmYCw6wfmJjF0l/uYg==
   dependencies:
-    "@typescript-eslint/scope-manager" "4.11.0"
-    "@typescript-eslint/types" "4.11.0"
-    "@typescript-eslint/typescript-estree" "4.11.0"
+    "@typescript-eslint/scope-manager" "4.14.0"
+    "@typescript-eslint/types" "4.14.0"
+    "@typescript-eslint/typescript-estree" "4.14.0"
     debug "^4.1.1"
 
-"@typescript-eslint/scope-manager@4.11.0":
-  version "4.11.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.11.0.tgz#2d906537db8a3a946721699e4fc0833810490254"
-  integrity sha512-6VSTm/4vC2dHM3ySDW9Kl48en+yLNfVV6LECU8jodBHQOhO8adAVizaZ1fV0QGZnLQjQ/y0aBj5/KXPp2hBTjA==
+"@typescript-eslint/scope-manager@4.14.0":
+  version "4.14.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.14.0.tgz#55a4743095d684e1f7b7180c4bac2a0a3727f517"
+  integrity sha512-/J+LlRMdbPh4RdL4hfP1eCwHN5bAhFAGOTsvE6SxsrM/47XQiPSgF5MDgLyp/i9kbZV9Lx80DW0OpPkzL+uf8Q==
   dependencies:
-    "@typescript-eslint/types" "4.11.0"
-    "@typescript-eslint/visitor-keys" "4.11.0"
+    "@typescript-eslint/types" "4.14.0"
+    "@typescript-eslint/visitor-keys" "4.14.0"
 
-"@typescript-eslint/types@4.11.0":
-  version "4.11.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.11.0.tgz#86cf95e7eac4ccfd183f9fcf1480cece7caf4ca4"
-  integrity sha512-XXOdt/NPX++txOQHM1kUMgJUS43KSlXGdR/aDyEwuAEETwuPt02Nc7v+s57PzuSqMbNLclblQdv3YcWOdXhQ7g==
+"@typescript-eslint/types@4.14.0":
+  version "4.14.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.14.0.tgz#d8a8202d9b58831d6fd9cee2ba12f8a5a5dd44b6"
+  integrity sha512-VsQE4VvpldHrTFuVPY1ZnHn/Txw6cZGjL48e+iBxTi2ksa9DmebKjAeFmTVAYoSkTk7gjA7UqJ7pIsyifTsI4A==
 
-"@typescript-eslint/typescript-estree@4.11.0":
-  version "4.11.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.11.0.tgz#1144d145841e5987d61c4c845442a24b24165a4b"
-  integrity sha512-eA6sT5dE5RHAFhtcC+b5WDlUIGwnO9b0yrfGa1mIOIAjqwSQCpXbLiFmKTdRbQN/xH2EZkGqqLDrKUuYOZ0+Hg==
+"@typescript-eslint/typescript-estree@4.14.0":
+  version "4.14.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.14.0.tgz#4bcd67486e9acafc3d0c982b23a9ab8ac8911ed7"
+  integrity sha512-wRjZ5qLao+bvS2F7pX4qi2oLcOONIB+ru8RGBieDptq/SudYwshveORwCVU4/yMAd4GK7Fsf8Uq1tjV838erag==
   dependencies:
-    "@typescript-eslint/types" "4.11.0"
-    "@typescript-eslint/visitor-keys" "4.11.0"
+    "@typescript-eslint/types" "4.14.0"
+    "@typescript-eslint/visitor-keys" "4.14.0"
     debug "^4.1.1"
     globby "^11.0.1"
     is-glob "^4.0.1"
@@ -751,12 +752,12 @@
     semver "^7.3.2"
     tsutils "^3.17.1"
 
-"@typescript-eslint/visitor-keys@4.11.0":
-  version "4.11.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.11.0.tgz#906669a50f06aa744378bb84c7d5c4fdbc5b7d51"
-  integrity sha512-tRYKyY0i7cMk6v4UIOCjl1LhuepC/pc6adQqJk4Is3YcC6k46HvsV9Wl7vQoLbm9qADgeujiT7KdLrylvFIQ+A==
+"@typescript-eslint/visitor-keys@4.14.0":
+  version "4.14.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.14.0.tgz#b1090d9d2955b044b2ea2904a22496849acbdf54"
+  integrity sha512-MeHHzUyRI50DuiPgV9+LxcM52FCJFYjJiWHtXlbyC27b80mfOwKeiKI+MHOTEpcpfmoPFm/vvQS88bYIx6PZTA==
   dependencies:
-    "@typescript-eslint/types" "4.11.0"
+    "@typescript-eslint/types" "4.14.0"
     eslint-visitor-keys "^2.0.0"
 
 abab@^2.0.3:
@@ -1520,10 +1521,10 @@ escodegen@^1.14.1:
   optionalDependencies:
     source-map "~0.6.1"
 
-eslint-config-prettier@7.1.0:
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-7.1.0.tgz#5402eb559aa94b894effd6bddfa0b1ca051c858f"
-  integrity sha512-9sm5/PxaFG7qNJvJzTROMM1Bk1ozXVTKI0buKOyb0Bsr1hrwi0H/TzxF/COtf1uxikIK8SwhX7K6zg78jAzbeA==
+eslint-config-prettier@7.2.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-7.2.0.tgz#f4a4bd2832e810e8cc7c1411ec85b3e85c0c53f9"
+  integrity sha512-rV4Qu0C3nfJKPOAhFujFxB7RMP+URFyQqqOZW9DMRD7ZDTFyjaIlETU3xzHELt++4ugC0+Jm084HQYkkJe+Ivg==
 
 eslint-import-resolver-node@^0.3.4:
   version "0.3.4"
@@ -1560,10 +1561,10 @@ eslint-plugin-import@2.22.1:
     resolve "^1.17.0"
     tsconfig-paths "^3.9.0"
 
-eslint-plugin-prettier@3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-3.3.0.tgz#61e295349a65688ffac0b7808ef0a8244bdd8d40"
-  integrity sha512-tMTwO8iUWlSRZIwS9k7/E4vrTsfvsrcM5p1eftyuqWH25nKsz/o6/54I7jwQ/3zobISyC7wMy9ZsFwgTxOcOpQ==
+eslint-plugin-prettier@3.3.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-3.3.1.tgz#7079cfa2497078905011e6f82e8dd8453d1371b7"
+  integrity sha512-Rq3jkcFY8RYeQLgk2cCwuc0P7SEFwDravPhsJZOQ5N4YI4DSg50NyqJ/9gdZHzQlHf8MvafSesbNJCcP/FF6pQ==
   dependencies:
     prettier-linter-helpers "^1.0.0"
 
@@ -1612,13 +1613,13 @@ eslint-visitor-keys@^2.0.0:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-2.0.0.tgz#21fdc8fbcd9c795cc0321f0563702095751511a8"
   integrity sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==
 
-eslint@7.16.0:
-  version "7.16.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-7.16.0.tgz#a761605bf9a7b32d24bb7cde59aeb0fd76f06092"
-  integrity sha512-iVWPS785RuDA4dWuhhgXTNrGxHHK3a8HLSMBgbbU59ruJDubUraXN8N5rn7kb8tG6sjg74eE0RA3YWT51eusEw==
+eslint@7.18.0:
+  version "7.18.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-7.18.0.tgz#7fdcd2f3715a41fe6295a16234bd69aed2c75e67"
+  integrity sha512-fbgTiE8BfUJZuBeq2Yi7J3RB3WGUQ9PNuNbmgi6jt9Iv8qrkxfy19Ds3OpL1Pm7zg3BtTVhvcUZbIRQ0wmSjAQ==
   dependencies:
     "@babel/code-frame" "^7.0.0"
-    "@eslint/eslintrc" "^0.2.2"
+    "@eslint/eslintrc" "^0.3.0"
     ajv "^6.10.0"
     chalk "^4.0.0"
     cross-spawn "^7.0.2"
@@ -1642,7 +1643,7 @@ eslint@7.16.0:
     js-yaml "^3.13.1"
     json-stable-stringify-without-jsonify "^1.0.1"
     levn "^0.4.1"
-    lodash "^4.17.19"
+    lodash "^4.17.20"
     minimatch "^3.0.4"
     natural-compare "^1.4.0"
     optionator "^0.9.1"


### PR DESCRIPTION
This PR aims at adding some export rules to our node config.
- https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/group-exports.md
- https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/exports-last.md

This is not perfect. For example, with this config, we would still be allowed to do

```ts
const LoginsOverviewPage: React.FC<LoginsOverviewPageProps> = ({
  sortedIdentities,
}) => {};

export default LoginsOverviewPage;

export const getServerSideProps: GetServerSideProps = async (context) => {
  return wrapMiddlewaresForSSR<{ sortedIdentities: SortedIdentities }>(
    context,
    [withLogger, withSentry, withAuth],
    async (request) => {}
  );
};
```
but we couldn't find a way so far to prevent this.

I added `internal` for import groups to add `@src/` alias path to it as default.

I also took the time to bump the following deps:
```ts
  @typescript-eslint/eslint-plugin  dev    ~1mo  4.11.0  →  4.14.0   ~4d
  @typescript-eslint/parser         dev    ~1mo  4.11.0  →  4.14.0   ~4d
  eslint                            dev    ~1mo  7.16.0  →  7.18.0   ~6d
  eslint-config-prettier            dev    ~1mo   7.1.0  →   7.2.0   ~4d
  eslint-plugin-prettier            dev    ~1mo   3.3.0  →   3.3.1  ~18d

  4 minor, 1 patch updates
```